### PR TITLE
Switch to Node.js env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 
 ## Installation
 
-This plugin is written in Typescript, so you need Node.js installed to use it.
-
-### Install Node.js
-
-To install Node.js, go to https://nodejs.org/ and download the LTS (Long Term Support) version. Alternatively, you can use [nvm-windows](https://github.com/coreybutler/nvm-windows).
-
-### Install the plugin
-
 You can find this plugin in Flow's Plugin Store, or by running this command in Flow Launcher:
 
 ```

--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
   "Name": "Search MDN",
   "Description": "Search MDN Web Docs",
   "Author": "Gabriel Carloto",
-  "Version": "1.0.0",
-  "Language": "executable",
+  "Version": "1.0.1",
+  "Language": "typescript",
   "Website": "https://github.com/gabrielcarloto/flow-search-mdn",
-  "ExecuteFileName": "run.bat",
+  "ExecuteFileName": "./build/index.js",
   "IcoPath": "app.png"
 }

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,0 @@
-@echo off
-SET plugin_dir=%~dp0%
-node "%plugin_dir%/build/index.js" %*


### PR DESCRIPTION
Hi there, this PR will switch the plugin to use Flow's automatic Node.js environment setup. User will be prompted to install/select Node.js, so manual installation will no longer be required.